### PR TITLE
Add apikey in ZapClient

### DIFF
--- a/tasks/zaproxy.js
+++ b/tasks/zaproxy.js
@@ -101,7 +101,7 @@ module.exports = function (grunt) {
     var options = this.options({
       host: 'localhost',
       port: '8080',
-      apiKey: '7c3sdphhcg24l7hnjj0dgeg3as'
+      apiKey: 'null'
     });
 
     var asyncDone = this.async();
@@ -115,15 +115,11 @@ module.exports = function (grunt) {
       }
     };
 
-    console.log('SERVER_HOST : ' + options.host);
-    console.log('SERVER_PORT : ' + options.port);
-    console.log('APIKEY : ' + options.apiKey);
-
-    var options = { proxy: 'http://' + options.host + ':' + options.port, apikey: options.apiKey };
+    var options = { proxy: 'http://' + options.host + ':' + options.port};
 
     var zaproxy = new ZapClient(options);
     grunt.log.write('Stopping ZAProxy: ');
-    zaproxy.core.shutdown(function (err) {
+    zaproxy.core.shutdown(options.apiKey, function (err) {
       if (err) {
         grunt.fail.warn('ZAProxy does not appear to be running: ' + JSON.stringify(err, null, 2));
         done();
@@ -302,7 +298,7 @@ module.exports = function (grunt) {
     grunt.log.write('Waiting for scanning to finish: ');
     waitForPassive(zaproxy, function (err) {
       if (err) {
-        grunt.fail.warn('ZAProxy does not appear to be running.');
+        grunt.fail.warn('ZAProxy does not appear to be running: ' + JSON.stringify(err, null, 2));
         done();
         return;
       }
@@ -311,7 +307,7 @@ module.exports = function (grunt) {
       grunt.log.write('Checking for alerts: ');
       zaproxy.core.alerts('', '', '', function (err, res) {
         if (err) {
-          grunt.fail.warn('ZAProxy does not appear to be running.');
+          grunt.fail.warn('ZAProxy does not appear to be running: ' + JSON.stringify(err, null, 2));
           done();
           return;
         }
@@ -370,7 +366,7 @@ module.exports = function (grunt) {
         try {
           xslt = require('node_xslt');
         } catch (e) {
-          grunt.log.error('Unable to generate HTML report because node_xslt is not installed. Make sure that you have the required dependencies for node_xslt.');
+          grunt.log.error('Unable to generate HTML report because node_xslt is not installed. Make sure that you have the required dependencies for node_xslt: ' + JSON.stringify(e, null, 2));
           done(false);
           return;
         }

--- a/tasks/zaproxy.js
+++ b/tasks/zaproxy.js
@@ -60,7 +60,7 @@ module.exports = function (grunt) {
     });
     child.on('error', function (err) {
       if (err.code === 'ENOENT') {
-        grunt.fail.fatal('Error launching ZAProxy. Make sure that ZAProxy is installed and zap.sh is available on the executable path.');
+        grunt.fail.fatal('Error launching ZAProxy. Make sure that ZAProxy is installed and zap.sh is available on the executable path: ' + JSON.stringify(err, null, 2));
       }
     });
 

--- a/tasks/zaproxy.js
+++ b/tasks/zaproxy.js
@@ -100,7 +100,8 @@ module.exports = function (grunt) {
     // Set up options.
     var options = this.options({
       host: 'localhost',
-      port: '8080'
+      port: '8080',
+      apiKey: '7c3sdphhcg24l7hnjj0dgeg3as'
     });
 
     var asyncDone = this.async();
@@ -114,11 +115,17 @@ module.exports = function (grunt) {
       }
     };
 
-    var zaproxy = new ZapClient({ proxy: 'http://' + options.host + ':' + options.port });
+    console.log('SERVER_HOST : ' + options.host);
+    console.log('SERVER_PORT : ' + options.port);
+    console.log('APIKEY : ' + options.apiKey);
+
+    var options = { proxy: 'http://' + options.host + ':' + options.port, apikey: options.apiKey };
+
+    var zaproxy = new ZapClient(options);
     grunt.log.write('Stopping ZAProxy: ');
     zaproxy.core.shutdown(function (err) {
       if (err) {
-        grunt.log.writeln('ZAProxy does not appear to be running.');
+        grunt.fail.warn('ZAProxy does not appear to be running: ' + JSON.stringify(err, null, 2));
         done();
         return;
       }


### PR DESCRIPTION
This PR is a sample in order to add apikey to ZapClient.
It is not yet working.

I guess first issue in zap must be resolved
Issue is https://github.com/zaproxy/zaproxy/issues/1668

As you can see in above issue, workaround is to remove apikey from zaproxy.
But it would be nice anyway to be able to send apikey in the futur.

Can I add:

```
grunt.fail.warn('ZAProxy does not appear to be running: ' + JSON.stringify(err, null, 2));
```

In a few days, I will remove others apikey code (which is more a sample for zaproxy team)