### PR TITLE
adding capability to choose what kind of risks should fail the zap_results task

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ In your project's Gruntfile, add a section named `zap_results` to the data objec
 
 ```js
 grunt.initConfig({
-  'zap_results: {
+  'zap_results': {
     options: {
       // Task-specific options go here.
     }
@@ -311,6 +311,13 @@ grunt.initConfig({
 ### Options
 
 No options are available for this task.
+
+#### options.risks
+Type: `Array`
+
+Default value: `[High, Medium, Low, Informational]`
+
+A list of risks that should make this task fail. By default it fails for any risk, but it is possible to configure to break to specific risks. E.g: ['High']
 
 ### Usage Examples
 A typical ZAProxy run consists of the following steps:

--- a/tasks/zaproxy.js
+++ b/tasks/zaproxy.js
@@ -324,6 +324,7 @@ module.exports = function (grunt) {
 
           // set a flag so that the cleanup task can fail the build
           grunt.config.set('zap_alert.failed', true);
+          grunt.config.set('zap_alert.alerts', alerts);
         } else {
           grunt.config.set('zap_alert.failed', false);
           grunt.log.ok();
@@ -387,12 +388,25 @@ module.exports = function (grunt) {
 
   grunt.registerTask('zap_results', 'It fails if found an alert that should not be ignored', function () {
     var done = this.async();
+
+    var options = this.options({
+      risks : ['High', 'Medium', 'Low', 'Informational']
+    });
+
     grunt.log.write('Verifying alert errors...');
-    if (grunt.config.get('zap_alert.failed')) {
-      grunt.log.write('Error found!');
+
+    var alerts = grunt.config.get('zap_alert.alerts') || [];
+
+    var filteredAlerts = alerts.filter(function(alert){
+      return options.risks.indexOf(alert.risk) > -1;
+    });
+
+    if (grunt.config.get('zap_alert.failed') && filteredAlerts.length > 0) {
+      grunt.fail.warn('Error found!');
       done(false);
     }
 
+    grunt.log.write('No errors found');
     done(true);
 
   });


### PR DESCRIPTION
The idea is to specify which kind of risks will make the build fail. It is possible that people don't want to make the grunt task to fail because there 2 alerts that are informational, for instance. 